### PR TITLE
Removing + signs from ADD operations

### DIFF
--- a/api/controllers/arithmeticController.js
+++ b/api/controllers/arithmeticController.js
@@ -11,7 +11,7 @@ exports.calculate = function(req, res) {
   });
 
   var operations = {
-    'add':      function(a,b) { return +a + +b },
+    'add':      function(a,b) { return a + b },
     'subtract': function(a,b) { return a - b },
     'multiply': function(a,b) { return a * b },
     'divide':   function(a,b) { return a / b },

--- a/api/controllers/arithmeticController.js
+++ b/api/controllers/arithmeticController.js
@@ -11,7 +11,8 @@ exports.calculate = function(req, res) {
   });
 
   var operations = {
-    'add':      function(a,b) { return a + b },
+  //To avoid string concatination
+    'add':      function(a,b) { return +a + +b },
     'subtract': function(a,b) { return a - b },
     'multiply': function(a,b) { return a * b },
     'divide':   function(a,b) { return a / b },


### PR DESCRIPTION
'add':      function(a,b) { return +a + +b } changed to 
'add':      function(a,b) { return a + b }